### PR TITLE
Add member "CiscoISE" to SplashPage enum

### DIFF
--- a/Meraki.Api/Data/SplashPage.cs
+++ b/Meraki.Api/Data/SplashPage.cs
@@ -74,6 +74,12 @@ public enum SplashPage
 	GoogleOAuth,
 
 	/// <summary>
+	/// Enum CiscoISE for "Cisco ISE"
+	/// </summary>
+	[EnumMember(Value = "Cisco ISE")]
+	CiscoISE,
+
+	/// <summary>
 	/// Enum Sponsoredguest for "Sponsored guest"
 	/// </summary>
 	[EnumMember(Value = "Sponsored guest")]


### PR DESCRIPTION
'Cisco ISE' value was missing in the SplashPage enum